### PR TITLE
Default user zone style to Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ Config is stored at `~/.pi/agent/pi-droid-styling.json`:
     "answering": "Answering",
     "running": "Cooking"
   },
-  "userZoneStyle": "droid",
+  "userZoneStyle": "gemini",
   "fixedUserZone": false,
   "forceOSC11": false
 }
 ```
 
 `alwaysExpanded` only sets the initial tool-output expansion state for a session; Pi core Ctrl+O remains authoritative afterward.
-`userZoneStyle` selects a built-in presentation preset for the user input zone in both normal and fixed modes. Supported values are `droid` and `gemini`; theme files keep using the existing extras/color format. `droid` is the default boxed layout, while `gemini` uses a Gemini-like status/input/footer layout with compact `provider model · level` model info before the unchanged token stats on the top row, branch status on the right, an always-visible divider before the status row using the same theme border color as tool-call boxes, a borderless `❯` input row with Gemini-style half-line background padding, fixed-zone shortcut hints right-aligned on the footer/status row, and dim wrapped workspace/status footer values without labels, sandbox, or quota columns.
+`userZoneStyle` selects a built-in presentation preset for the user input zone in both normal and fixed modes. Supported values are `gemini` and `droid`; theme files keep using the existing extras/color format. `gemini` is the default Gemini-like status/input/footer layout with compact `provider model · level` model info before the unchanged token stats on the top row, branch status on the right, an always-visible divider before the status row using the same theme border color as tool-call boxes, a borderless `❯` input row with Gemini-style half-line background padding, fixed-zone shortcut hints right-aligned on the footer/status row, and dim wrapped workspace/status footer values without labels, sandbox, or quota columns. `droid` remains available as the boxed legacy layout.
 `fixedUserZone` is opt-in. When enabled, the status/widgets/editor/footer cluster is kept fixed at the bottom while chat/feed output renders in the scrollable region above it.
 `forceOSC11` is off by default on Windows/WSL/Windows Terminal. Set it to `true` only if you want to test OSC 11 terminal background sync there.
 

--- a/config.ts
+++ b/config.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { homedir } from "os";
-import { DEFAULT_USER_ZONE_STYLE, isUserZoneStyleName, normalizeUserZoneStyleName, type UserZoneStyleName } from "./user-zone/designs.js";
+import { DEFAULT_USER_ZONE_STYLE, FALLBACK_USER_ZONE_STYLE, isUserZoneStyleName, normalizeUserZoneStyleName, type UserZoneStyleName } from "./user-zone/designs.js";
 
 export type CustomWorkingMessageConfig = Record<"working" | "thinking" | "answering" | "running", string>;
 
@@ -102,7 +102,7 @@ function backfillUserZoneStyle(config: Record<string, unknown>): boolean {
 	}
 	if (isUserZoneStyleName(value)) return false;
 	if (typeof value === "string" && value.trim().length > 0) return false;
-	config.userZoneStyle = DEFAULT_USER_ZONE_STYLE;
+	config.userZoneStyle = FALLBACK_USER_ZONE_STYLE;
 	return true;
 }
 

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -27,7 +27,7 @@ This markdown file is a human-readable fallback for the initial brownfield basel
 | US-009 | Fixed-zone notices render in a reserved themed bottom footer row and copy feedback uses that local surface | yes | yes | no | pending | implemented | Pending validation for notice render smoke, scoped TypeScript no-emit, render profile, and srcwalk review; manual Pi themed pill smoke pending |
 | US-014 | `customWorkingMessage` defaults to an object of loader labels, migrates legacy booleans, backfills partial objects, and renders configured loader labels | yes | yes | no | pending | implemented | `npm run test:working-message`; `git diff --check`; `semantic_review` |
 | US-016 | Theme extras ending in `Color` resolve semantic theme tokens/aliases while non-color extras remain literal | yes | yes | no | no | implemented | `npm run test:theme-extras`; `npm run test:startup-resources`; `npm run test:working-message`; `git diff --check`; `semantic_review` |
-| US-017 | `userZoneStyle` selects `droid` or `gemini` user-zone presets without changing theme format, with Gemini status/input/footer and fixed-zone footer hint behavior | yes | yes | no | pending | implemented | `npm run test:user-zone-style`; `npm run test:working-message`; `npm run test:theme-extras`; `git diff --check`; `semantic_review` |
+| US-017 | `userZoneStyle` defaults to `gemini` and can select `droid` or `gemini` presets without changing theme format, with Gemini status/input/footer and fixed-zone footer hint behavior | yes | yes | no | pending | implemented | `npm run test:user-zone-style`; `npm run test:working-message`; `npm run test:theme-extras`; `git diff --check`; `semantic_review` |
 
 ## Evidence Rules
 

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -35,7 +35,7 @@ Current options:
     "answering": "Answering",
     "running": "Cooking"
   },
-  "userZoneStyle": "droid",
+  "userZoneStyle": "gemini",
   "fixedUserZone": false,
   "forceOSC11": false
 }
@@ -44,7 +44,7 @@ Current options:
 `alwaysExpanded` only sets the initial tool-output expansion state for a session; Pi core Ctrl+O remains authoritative afterward.
 `customWorkingMessage` is on by default and accepts `working`, `thinking`, `answering`, and `running` strings for themed loader labels.
 Legacy `customWorkingMessage: true` or `false` values are normalized back to the default label object.
-`userZoneStyle` accepts `droid` or `gemini` and changes built-in user-zone presentation in both normal and fixed modes; themes keep the same extras/color format. `droid` is the default boxed layout. `gemini` renders compact `provider model · level` model info before unchanged token stats on the top status row with branch status on the right, renders an always-visible divider before the status row using the same theme border color as tool-call boxes, keeps a borderless droid prompt row with `❯` and Gemini-style half-line background padding, right-aligns fixed-zone shortcut hints on the footer/status row, and renders dim wrapped workspace/status footer values without labels, sandbox, or quota columns.
+`userZoneStyle` accepts `gemini` or `droid` and changes built-in user-zone presentation in both normal and fixed modes; themes keep the same extras/color format. `gemini` is the default layout and renders compact `provider model · level` model info before unchanged token stats on the top status row with branch status on the right, renders an always-visible divider before the status row using the same theme border color as tool-call boxes, keeps a borderless droid prompt row with `❯` and Gemini-style half-line background padding, right-aligns fixed-zone shortcut hints on the footer/status row, and renders dim wrapped workspace/status footer values without labels, sandbox, or quota columns. `droid` remains available as the boxed legacy layout.
 `fixedUserZone` is off by default; enabling it activates terminal scroll isolation for the user zone rather than a cosmetic-only layout change.
 `forceOSC11` keeps OSC 11 disabled on Windows/WSL/Windows Terminal unless explicitly enabled for user testing.
 

--- a/docs/stories/US-017-user-zone-style-presets.md
+++ b/docs/stories/US-017-user-zone-style-presets.md
@@ -14,8 +14,8 @@ Users can select a built-in user-zone presentation preset with `userZoneStyle`. 
 
 The supported preset set is intentionally small:
 
-- `droid` is the default boxed user-zone layout.
-- `gemini` is a Gemini-like status/input/footer layout. Its top status row keeps droid runtime stats without the `[stat]` or `Tokens:` labels, places compact `provider model · level` model info before the unchanged token stats with a theme-muted pipe separator, and moves git branch/status to the right. It renders an always-visible horizontal divider before the status row using the same theme border token as tool-call boxes. Its input row is borderless, keeps the droid `❯` prompt icon, and uses Gemini-style half-line background padding rather than full blank padding rows. Its footer renders dim wrapped workspace/status values without column labels and does not render sandbox or quota columns.
+- `gemini` is the default Gemini-like status/input/footer layout. Its top status row keeps droid runtime stats without the `[stat]` or `Tokens:` labels, places compact `provider model · level` model info before the unchanged token stats with a theme-muted pipe separator, and moves git branch/status to the right. It renders an always-visible horizontal divider before the status row using the same theme border token as tool-call boxes. Its input row is borderless, keeps the droid `❯` prompt icon, and uses Gemini-style half-line background padding rather than full blank padding rows. Its footer renders dim wrapped workspace/status values without column labels and does not render sandbox or quota columns.
+- `droid` remains available as the boxed legacy user-zone layout.
 
 ## Relevant Product Docs
 
@@ -27,9 +27,9 @@ The supported preset set is intentionally small:
 
 ## Acceptance Criteria
 
-- `userZoneStyle` defaults to `"droid"` and is scaffolded/backfilled in `~/.pi/agent/pi-droid-styling.json`.
+- `userZoneStyle` defaults to `"gemini"` when missing and is scaffolded in `~/.pi/agent/pi-droid-styling.json`; invalid/non-string values fall back to `"droid"` as the safe legacy layout.
 - Supported styles are the code-defined preset set `droid` and `gemini`; invalid or non-string values normalize to `droid`.
-- The default `droid` style preserves the existing BoxEditor/user zone layout and fixed-zone shell affordances.
+- The `droid` style preserves the existing BoxEditor/user zone layout and fixed-zone shell affordances when selected explicitly or used as the invalid-value fallback.
 - The `gemini` style changes user-zone presentation in normal mode because BoxEditor consumes the resolved style directly.
 - The `gemini` style renders a top status row without `[stat]` or `Tokens:`, places compact `provider model · level` model info before the unchanged token stats with a theme-muted pipe separator, puts git branch/status on the right of that row, renders an always-visible divider before the status row using the same theme border token as tool-call boxes, keeps a borderless `❯` input row with Gemini-style half-line background padding and without full blank padding rows, and renders dim wrapped workspace/status footer values without column labels.
 - The `gemini` style does not render sandbox or quota columns.
@@ -51,7 +51,7 @@ The supported preset set is intentionally small:
 
 | Layer | Expected proof |
 | --- | --- |
-| Unit | Focused smoke for default scaffold, valid gemini preservation, invalid fallback/backfill, style resolver identity, BoxEditor droid/gemini render markers and omissions, and fixed-zone style options. |
+| Unit | Focused smoke for default gemini scaffold, valid gemini preservation, invalid droid fallback/backfill, style resolver identity, BoxEditor droid/gemini render markers and omissions, and fixed-zone style options. |
 | Integration | Focused TypeScript compile for config, user-zone style module, BoxEditor, fixed-zone installer/compositor, and index; `git diff --check`; semantic review. |
 | E2E | Manual Pi smoke recommended for both presets in fixed and non-fixed modes. |
 | Platform | Terminal visual/manual smoke still recommended because fixed-zone shell uses compositor painting. |
@@ -63,7 +63,7 @@ US-017 now documents the narrowed preset set (`droid`, `gemini`) and reusable `n
 
 ## Evidence
 
-- `npm run test:user-zone-style` passed: focused TypeScript compile, default scaffold/backfill, valid `gemini` preservation, invalid/non-string fallback, inherited-key guard, style resolver checks, BoxEditor render smoke for `droid`/`gemini`, compact gemini model visual, single accent thinking-level color, unchanged token stat formatting, always-visible tool-border-colored divider behavior, gemini branch/status/input/footer markers, sandbox/quota omissions, and fixed-zone scrollbar/footer-hint affordance smoke.
+- `npm run test:user-zone-style` passed: focused TypeScript compile, default gemini scaffold/backfill, valid `gemini` preservation, invalid/non-string droid fallback, inherited-key guard, style resolver checks, BoxEditor render smoke for `droid`/`gemini`, compact gemini model visual, single accent thinking-level color, unchanged token stat formatting, always-visible tool-border-colored divider behavior, gemini branch/status/input/footer markers, sandbox/quota omissions, and fixed-zone scrollbar/footer-hint affordance smoke.
 - `npm run test:working-message` passed after the config/style surface changed.
 - `npm run test:theme-extras` passed to confirm existing theme extras/color format remains valid.
 - `PI_DROID_PROFILE_BENCH_ITERATIONS=20 PI_DROID_PROFILE_BENCH_ROOT_LINES=120 npm run profile:render` passed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-droid-styling",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-droid-styling",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "^0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-droid-styling",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Custom UI styling for Pi: compact startup UI, boxed editor, tool badges, message prefixes, and footer stats.",
   "type": "module",
   "main": "index.ts",

--- a/scripts/user-zone-style-smoke.mjs
+++ b/scripts/user-zone-style-smoke.mjs
@@ -142,7 +142,8 @@ async function runStyleResolverSmoke() {
 	assert(styles.resolveUserZoneStyle("gemini").fixed.showScrollbar === true, "gemini fixed-zone should keep scrollbar affordance");
 	assert(styles.resolveUserZoneStyle("droid").fixed.scrollHintRightInset === 2, "droid fixed-zone should preserve cursor hint inset");
 	assert(styles.resolveUserZoneStyle("gemini").fixed.scrollHintRightInset === 0, "gemini fixed-zone should not leave trailing hint inset");
-	assert(styles.resolveUserZoneStyle("unknown").name === "droid", "unknown style did not resolve to droid");
+	assert(styles.resolveUserZoneStyle(undefined).name === "gemini", "missing style did not resolve to gemini default");
+	assert(styles.resolveUserZoneStyle("unknown").name === "droid", "unknown style did not resolve to droid fallback");
 	assert(styles.resolveUserZoneStyle("toString").name === "droid", "inherited object key did not resolve to droid");
 	console.log("style resolver smoke ok");
 }
@@ -320,8 +321,8 @@ prepareWorkDir();
 compileChangedSurface();
 
 await runConfigSmoke("scaffold default style", undefined, ({ config, raw }) => {
-	assert(raw.userZoneStyle === "droid", "scaffold did not write default userZoneStyle");
-	assert(config.userZoneStyle === "droid", "default config did not normalize to droid");
+	assert(raw.userZoneStyle === "gemini", "scaffold did not write default userZoneStyle");
+	assert(config.userZoneStyle === "gemini", "default config did not normalize to gemini");
 });
 
 await runConfigSmoke("valid style preserved", '{"userZoneStyle":"gemini"}', ({ config, raw }) => {

--- a/user-zone/designs.ts
+++ b/user-zone/designs.ts
@@ -52,7 +52,8 @@ const USER_ZONE_STYLE_NAME_SET: UserZoneStyleNameSet = {
 	gemini: true,
 };
 
-export const DEFAULT_USER_ZONE_STYLE: UserZoneStyleName = "droid";
+export const DEFAULT_USER_ZONE_STYLE: UserZoneStyleName = "gemini";
+export const FALLBACK_USER_ZONE_STYLE: UserZoneStyleName = "droid";
 
 export const USER_ZONE_STYLES: Record<UserZoneStyleName, UserZoneStyle> = {
 	droid: {
@@ -138,7 +139,8 @@ export function isUserZoneStyleName(value: unknown): value is UserZoneStyleName 
 }
 
 export function normalizeUserZoneStyleName(value: unknown): UserZoneStyleName {
-	return isUserZoneStyleName(value) ? value : DEFAULT_USER_ZONE_STYLE;
+	if (value === undefined) return DEFAULT_USER_ZONE_STYLE;
+	return isUserZoneStyleName(value) ? value : FALLBACK_USER_ZONE_STYLE;
 }
 
 export function resolveUserZoneStyle(value: unknown): UserZoneStyle {


### PR DESCRIPTION
## Summary
- Default missing/scaffolded `userZoneStyle` to `gemini`.
- Keep invalid/non-string and unknown runtime fallback on `droid` as the safe legacy layout.
- Bump package version to `2.5.2`.

## Verification
- `npm run test:user-zone-style`
- `npm run test:working-message`
- `npm run test:theme-extras`
- `git diff --check`
- `semantic_review working-tree`
