### PR TITLE
Style Pi core special message blocks

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ editor/
   BoxEditor component and editor-specific rendering
 
 messages/
-  Assistant/user message prefix patches
+  Assistant/user message prefix patches and boxed Pi core special message block styling
 
 tool-tags/
   Tool call renderers, badges, elapsed metrics, and tool-output formatting

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -28,6 +28,7 @@ This markdown file is a human-readable fallback for the initial brownfield basel
 | US-014 | `customWorkingMessage` defaults to an object of loader labels, migrates legacy booleans, backfills partial objects, and renders configured loader labels | yes | yes | no | pending | implemented | `npm run test:working-message`; `git diff --check`; `semantic_review` |
 | US-016 | Theme extras ending in `Color` resolve semantic theme tokens/aliases while non-color extras remain literal | yes | yes | no | no | implemented | `npm run test:theme-extras`; `npm run test:startup-resources`; `npm run test:working-message`; `git diff --check`; `semantic_review` |
 | US-017 | `userZoneStyle` defaults to `gemini` and can select `droid` or `gemini` presets without changing theme format, with Gemini status/input/footer and fixed-zone footer hint behavior | yes | yes | no | pending | implemented | `npm run test:user-zone-style`; `npm run test:working-message`; `npm run test:theme-extras`; `git diff --check`; `semantic_review` |
+| US-018 | Pi core special message blocks (Compaction, Skill, Branch, and Custom) render as boxed blocks with page-surface background, reload-safe patches, custom fallback deduplication, no-box fallback background, and distinct special titles | yes | yes | no | no | implemented | `npm run test:core-message-blocks`; `npm run test:user-zone-style`; `semantic_review working-tree` |
 
 ## Evidence Rules
 

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,14 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { AssistantMessageComponent, copyToClipboard, InteractiveMode, ToolExecutionComponent } from "@earendil-works/pi-coding-agent";
+import {
+  AssistantMessageComponent,
+  BranchSummaryMessageComponent,
+  CompactionSummaryMessageComponent,
+  CustomMessageComponent,
+  InteractiveMode,
+  SkillInvocationMessageComponent,
+  ToolExecutionComponent,
+  copyToClipboard,
+} from "@earendil-works/pi-coding-agent";
 
 import { BoxEditor } from "./editor/box-editor.js";
 import { FIXED_ZONE_SCROLL_FRAME_MS, installFixedUserZone } from "./fixed-zone/install.js";
@@ -17,6 +26,7 @@ import { installAssistantMessagePrefix } from "./messages/assistant-prefix.js";
 import { installMarkdownCodeBlockRenderer } from "./messages/markdown-codeblock-renderer.js";
 import { installAssistantStreamingMarkdownCache } from "./messages/streaming-markdown-cache.js";
 import { installUserMessagePrefix } from "./messages/user-prefix.js";
+import { installCoreMessageBlockStyling, setCoreMessageBlockTheme } from "./messages/core-message-blocks.js";
 import { installRenderFrameDebug } from "./performance/render-frame-debug.js";
 import { installRenderAutowrapGuard } from "./performance/render-autowrap-guard.js";
 import { installRenderFrameBackground } from "./performance/render-frame-background.js";
@@ -58,6 +68,12 @@ export default function (pi: ExtensionAPI) {
 	suppressStartupModelScopeLog();
 	installStartupUiPatch(InteractiveMode);
 	registerToolCallTags(pi);
+	installCoreMessageBlockStyling({
+		CompactionSummaryMessageComponent,
+		SkillInvocationMessageComponent,
+		BranchSummaryMessageComponent,
+		CustomMessageComponent,
+	});
 
 	let currentThinkingLevel: string | undefined;
 	const assistantSpeedTracker = createAssistantSpeedTracker();
@@ -206,6 +222,7 @@ export default function (pi: ExtensionAPI) {
 
 		setDefaultBadgeTheme(sessionUi.theme);
 		setToolSpacingTheme(sessionUi.theme);
+		setCoreMessageBlockTheme(sessionUi.theme);
 
 		sessionUi.setEditorComponent((tui, theme, kb) => {
 			const uiTheme = (sessionUi.theme ?? theme) as any;

--- a/messages/boxed-message-block.ts
+++ b/messages/boxed-message-block.ts
@@ -10,9 +10,6 @@ import {
 } from "../tool-tags/common.js";
 import { fgHex, isHexColor } from "../theme/ansi.js";
 import { getThemeExtra } from "../theme/theme-extras.js";
-import { safeVisibleWidth } from "../render-budget.js";
-
-export type MessageBlockTone = "info" | "success" | "error" | "pending";
 
 export type MessageBlockOptions = {
   kind: string;
@@ -21,7 +18,6 @@ export type MessageBlockOptions = {
   body: (contentWidth: number) => string[];
   bgName?: string;
   hasDivider?: boolean;
-  tone?: MessageBlockTone;
 };
 
 function formatMessageBlockTitle(theme: any, kind: string, title?: string): string {
@@ -44,7 +40,6 @@ export function renderBoxedMessageBlock(
     body,
     bgName = "customMessageBg",
     hasDivider = true,
-    tone = "info",
   } = options;
 
   let cache: { width: number; lines: string[] } | null = null;

--- a/messages/boxed-message-block.ts
+++ b/messages/boxed-message-block.ts
@@ -7,8 +7,6 @@ import {
   boxWidth,
   boxInnerWidth,
 } from "../tool-tags/common.js";
-import { fgHex, isHexColor } from "../theme/ansi.js";
-import { getThemeExtra } from "../theme/theme-extras.js";
 
 export type MessageBlockOptions = {
   kind: string;
@@ -21,10 +19,7 @@ export type MessageBlockOptions = {
 
 function formatMessageBlockTitle(theme: any, kind: string, title?: string, icon = "➔"): string {
   const rawTitle = title ? `${icon} ${kind} | ${title}` : `${icon} ${kind}`;
-  const bashPromptColor = getThemeExtra(theme, "bashPromptColor");
-  const coloredTitle = bashPromptColor && isHexColor(bashPromptColor)
-    ? fgHex(theme, bashPromptColor, rawTitle)
-    : theme.fg("bashMode", rawTitle);
+  const coloredTitle = theme.fg("accent", rawTitle);
   return typeof theme?.bold === "function" ? theme.bold(coloredTitle) : coloredTitle;
 }
 

--- a/messages/boxed-message-block.ts
+++ b/messages/boxed-message-block.ts
@@ -1,0 +1,87 @@
+import type { Component } from "@earendil-works/pi-tui";
+import {
+  boxBgLines,
+  boxBorder,
+  boxInsetDivider,
+  boxLine,
+  boxLineWithRight,
+  boxWidth,
+  boxInnerWidth,
+} from "../tool-tags/common.js";
+import { fgHex, isHexColor } from "../theme/ansi.js";
+import { getThemeExtra } from "../theme/theme-extras.js";
+import { safeVisibleWidth } from "../render-budget.js";
+
+export type MessageBlockTone = "info" | "success" | "error" | "pending";
+
+export type MessageBlockOptions = {
+  kind: string;
+  title?: string;
+  right?: string;
+  body: (contentWidth: number) => string[];
+  bgName?: string;
+  hasDivider?: boolean;
+  tone?: MessageBlockTone;
+};
+
+function formatMessageBlockTitle(theme: any, kind: string, title?: string): string {
+  const rawTitle = title ? `➔ ${kind} | ${title}` : `➔ ${kind}`;
+  const bashPromptColor = getThemeExtra(theme, "bashPromptColor");
+  const coloredTitle = bashPromptColor && isHexColor(bashPromptColor)
+    ? fgHex(theme, bashPromptColor, rawTitle)
+    : theme.fg("bashMode", rawTitle);
+  return typeof theme?.bold === "function" ? theme.bold(coloredTitle) : coloredTitle;
+}
+
+export function renderBoxedMessageBlock(
+  theme: any,
+  options: MessageBlockOptions,
+): Component {
+  const {
+    kind,
+    title,
+    right,
+    body,
+    bgName = "customMessageBg",
+    hasDivider = true,
+    tone = "info",
+  } = options;
+
+  let cache: { width: number; lines: string[] } | null = null;
+
+  return {
+    invalidate() { cache = null; },
+    render(width: number): string[] {
+      if (cache?.width === width) return cache.lines;
+
+      const renderedWidth = boxWidth(width);
+      const contentWidth = boxInnerWidth(renderedWidth);
+      const titleLine = formatMessageBlockTitle(theme, kind, title);
+
+      const lines: string[] = [];
+      lines.push(boxBorder(theme, "┌", "┐", renderedWidth));
+
+      if (right) {
+        const rightStyled = theme.fg("dim", right);
+        lines.push(boxLineWithRight(theme, titleLine, rightStyled, renderedWidth));
+      } else {
+        lines.push(boxLine(theme, titleLine, renderedWidth));
+      }
+
+      if (hasDivider) {
+        lines.push(boxInsetDivider(theme, renderedWidth));
+      }
+
+      const bodyLines = body(contentWidth);
+      for (const line of bodyLines) {
+        lines.push(boxLine(theme, line, renderedWidth));
+      }
+
+      lines.push(boxBorder(theme, "└", "┘", renderedWidth));
+
+      const rendered = boxBgLines(theme, lines, bgName);
+      cache = { width, lines: rendered };
+      return rendered;
+    },
+  };
+}

--- a/messages/boxed-message-block.ts
+++ b/messages/boxed-message-block.ts
@@ -16,10 +16,11 @@ export type MessageBlockOptions = {
   right?: string;
   body: (contentWidth: number) => string[];
   hasDivider?: boolean;
+  icon?: string;
 };
 
-function formatMessageBlockTitle(theme: any, kind: string, title?: string): string {
-  const rawTitle = title ? `➔ ${kind} | ${title}` : `➔ ${kind}`;
+function formatMessageBlockTitle(theme: any, kind: string, title?: string, icon = "➔"): string {
+  const rawTitle = title ? `${icon} ${kind} | ${title}` : `${icon} ${kind}`;
   const bashPromptColor = getThemeExtra(theme, "bashPromptColor");
   const coloredTitle = bashPromptColor && isHexColor(bashPromptColor)
     ? fgHex(theme, bashPromptColor, rawTitle)
@@ -44,6 +45,7 @@ export function renderBoxedMessageBlock(
     title,
     right,
     body,
+    icon = "➔",
     hasDivider = true,
   } = options;
 
@@ -56,7 +58,7 @@ export function renderBoxedMessageBlock(
 
       const renderedWidth = boxWidth(width);
       const contentWidth = boxInnerWidth(renderedWidth);
-      const titleLine = formatMessageBlockTitle(theme, kind, title);
+      const titleLine = formatMessageBlockTitle(theme, kind, title, icon);
 
       const lines: string[] = [];
       lines.push(boxBorder(theme, "┌", "┐", renderedWidth));

--- a/messages/boxed-message-block.ts
+++ b/messages/boxed-message-block.ts
@@ -1,6 +1,5 @@
 import type { Component } from "@earendil-works/pi-tui";
 import {
-  boxBgLines,
   boxBorder,
   boxInsetDivider,
   boxLine,
@@ -16,7 +15,6 @@ export type MessageBlockOptions = {
   title?: string;
   right?: string;
   body: (contentWidth: number) => string[];
-  bgName?: string;
   hasDivider?: boolean;
 };
 
@@ -29,6 +27,14 @@ function formatMessageBlockTitle(theme: any, kind: string, title?: string): stri
   return typeof theme?.bold === "function" ? theme.bold(coloredTitle) : coloredTitle;
 }
 
+/**
+ * Render a boxed message block.
+ *
+ * Returns only border/content lines with foreground styling.
+ * Background is applied by the parent Box (all patched components extend
+ * Box with customMessageBg bgFn), so this helper must NOT apply background
+ * itself — that would create a double-background conflict.
+ */
 export function renderBoxedMessageBlock(
   theme: any,
   options: MessageBlockOptions,
@@ -38,7 +44,6 @@ export function renderBoxedMessageBlock(
     title,
     right,
     body,
-    bgName = "customMessageBg",
     hasDivider = true,
   } = options;
 
@@ -74,9 +79,8 @@ export function renderBoxedMessageBlock(
 
       lines.push(boxBorder(theme, "└", "┘", renderedWidth));
 
-      const rendered = boxBgLines(theme, lines, bgName);
-      cache = { width, lines: rendered };
-      return rendered;
+      cache = { width, lines };
+      return lines;
     },
   };
 }

--- a/messages/core-message-blocks.ts
+++ b/messages/core-message-blocks.ts
@@ -73,6 +73,7 @@ function patchCompaction(ctor?: ComponentCtor): void {
 				title: `${tokenStr} tokens`,
 				right: expanded ? undefined : "(Ctrl+O to expand)",
 				body,
+				icon: "⊟",
 				hasDivider: expanded,
 			});
 			this.addChild(block);
@@ -111,6 +112,7 @@ function patchSkill(ctor?: ComponentCtor): void {
 				title: skillName,
 				right: expanded ? undefined : "(Ctrl+O to expand)",
 				body,
+				icon: "⊟",
 				hasDivider: expanded,
 			});
 			this.addChild(block);
@@ -145,6 +147,7 @@ function patchBranch(ctor?: ComponentCtor): void {
 				kind: "Branch",
 				right: expanded ? undefined : "(Ctrl+O to expand)",
 				body,
+				icon: "⊟",
 				hasDivider: expanded,
 			});
 			this.addChild(block);
@@ -210,6 +213,7 @@ function patchCustomMessage(ctor?: ComponentCtor): void {
 				kind: "Custom",
 				title: customType,
 				body,
+				icon: "⊟",
 				hasDivider: Boolean(text),
 			});
 

--- a/messages/core-message-blocks.ts
+++ b/messages/core-message-blocks.ts
@@ -1,0 +1,213 @@
+import { Markdown } from "@earendil-works/pi-tui";
+import { renderBoxedMessageBlock } from "./boxed-message-block.js";
+
+const PATCH_FLAG = "__droidCoreMessageBlocksPatched__";
+
+let cachedTheme: any = null;
+
+export function setCoreMessageBlockTheme(theme: any): void {
+	cachedTheme = theme;
+}
+
+type ComponentCtor = { prototype?: any };
+
+export function installCoreMessageBlockStyling(ctors: {
+	CompactionSummaryMessageComponent?: ComponentCtor;
+	SkillInvocationMessageComponent?: ComponentCtor;
+	BranchSummaryMessageComponent?: ComponentCtor;
+	CustomMessageComponent?: ComponentCtor;
+}): void {
+	const globalState = globalThis as Record<string, unknown>;
+	if (globalState[PATCH_FLAG]) return;
+	globalState[PATCH_FLAG] = true;
+
+	patchCompaction(ctors.CompactionSummaryMessageComponent);
+	patchSkill(ctors.SkillInvocationMessageComponent);
+	patchBranch(ctors.BranchSummaryMessageComponent);
+	patchCustomMessage(ctors.CustomMessageComponent);
+}
+
+function createMarkdownBody(text: string, markdownTheme: any, theme: any): (contentWidth: number) => string[] {
+	const md = new Markdown(text || "", 0, 0, markdownTheme, {
+		color: (t: string) => theme.fg("customMessageText", t),
+	});
+	return (contentWidth: number) => md.render(contentWidth);
+}
+
+function patchCompaction(ctor?: ComponentCtor): void {
+	const proto = ctor?.prototype;
+	if (!proto || typeof proto.updateDisplay !== "function") return;
+
+	const base = proto.updateDisplay;
+	proto.updateDisplay = function patchedCompactionUpdateDisplay(this: any) {
+		const theme = cachedTheme;
+		if (!theme || this.message == null) return base.call(this);
+
+		const tokensBefore = this.message.tokensBefore;
+		if (tokensBefore == null) return base.call(this);
+
+		this.clear();
+
+		const expanded = Boolean(this.expanded);
+		const summary = typeof this.message.summary === "string" ? this.message.summary : "";
+		const markdownTheme = this.markdownTheme;
+
+		const body = expanded && summary && markdownTheme
+			? createMarkdownBody(summary, markdownTheme, theme)
+			: () => [];
+
+		const tokenStr = tokensBefore.toLocaleString();
+
+		try {
+			const block = renderBoxedMessageBlock(theme, {
+				kind: "Compaction",
+				title: `${tokenStr} tokens`,
+				right: expanded ? undefined : "(Ctrl+O to expand)",
+				body,
+				bgName: "customMessageBg",
+				hasDivider: expanded,
+			});
+			this.addChild(block);
+		} catch {
+			return base.call(this);
+		}
+	};
+}
+
+function patchSkill(ctor?: ComponentCtor): void {
+	const proto = ctor?.prototype;
+	if (!proto || typeof proto.updateDisplay !== "function") return;
+
+	const base = proto.updateDisplay;
+	proto.updateDisplay = function patchedSkillUpdateDisplay(this: any) {
+		const theme = cachedTheme;
+		if (!theme || this.skillBlock == null) return base.call(this);
+
+		const skillName = this.skillBlock.name;
+		if (!skillName) return base.call(this);
+
+		this.clear();
+
+		const expanded = Boolean(this.expanded);
+		const content = typeof this.skillBlock.content === "string" ? this.skillBlock.content : "";
+		const markdownTheme = this.markdownTheme;
+
+		const body = expanded && content && markdownTheme
+			? createMarkdownBody(content, markdownTheme, theme)
+			: () => [];
+
+		try {
+			const block = renderBoxedMessageBlock(theme, {
+				kind: "Skill",
+				title: skillName,
+				right: expanded ? undefined : "(Ctrl+O to expand)",
+				body,
+				bgName: "customMessageBg",
+				hasDivider: expanded,
+			});
+			this.addChild(block);
+		} catch {
+			return base.call(this);
+		}
+	};
+}
+
+function patchBranch(ctor?: ComponentCtor): void {
+	const proto = ctor?.prototype;
+	if (!proto || typeof proto.updateDisplay !== "function") return;
+
+	const base = proto.updateDisplay;
+	proto.updateDisplay = function patchedBranchUpdateDisplay(this: any) {
+		const theme = cachedTheme;
+		if (!theme) return base.call(this);
+
+		this.clear();
+
+		const expanded = Boolean(this.expanded);
+		const summary = typeof this.message?.summary === "string" ? this.message.summary : "";
+		const markdownTheme = this.markdownTheme;
+
+		const body = expanded && summary && markdownTheme
+			? createMarkdownBody(summary, markdownTheme, theme)
+			: () => [];
+
+		try {
+			const block = renderBoxedMessageBlock(theme, {
+				kind: "Branch",
+				right: expanded ? undefined : "(Ctrl+O to expand)",
+				body,
+				bgName: "customMessageBg",
+				hasDivider: expanded,
+			});
+			this.addChild(block);
+		} catch {
+			return base.call(this);
+		}
+	};
+}
+
+function patchCustomMessage(ctor?: ComponentCtor): void {
+	const proto = ctor?.prototype;
+	if (!proto || typeof proto.rebuild !== "function") return;
+
+	const base = proto.rebuild;
+	proto.rebuild = function patchedCustomMessageRebuild(this: any) {
+		// Remove previous content component
+		if (this.customComponent) {
+			this.removeChild(this.customComponent);
+			this.customComponent = undefined;
+		}
+		this.removeChild(this.box);
+
+		// Try custom renderer first - it handles its own styling
+		if (this.customRenderer) {
+			try {
+				const component = this.customRenderer(this.message, { expanded: this._expanded }, cachedTheme);
+				if (component) {
+					this.customComponent = component;
+					this.addChild(component);
+					return;
+				}
+			} catch {
+				// Fall through to default rendering
+			}
+		}
+
+		// Default rendering: use boxed message block
+		const theme = cachedTheme;
+		if (!theme) return base.call(this);
+
+		// Extract text content
+		let text: string;
+		if (typeof this.message.content === "string") {
+			text = this.message.content;
+		} else if (Array.isArray(this.message.content)) {
+			text = this.message.content
+				.filter((c: any) => c.type === "text")
+				.map((c: any) => c.text)
+				.join("\n");
+		} else {
+			text = "";
+		}
+
+		const customType = this.message.customType || "Custom";
+		const markdownTheme = this.markdownTheme;
+
+		const body = text && markdownTheme
+			? createMarkdownBody(text, markdownTheme, theme)
+			: () => [];
+
+		try {
+			const block = renderBoxedMessageBlock(theme, {
+				kind: "Custom",
+				title: customType,
+				body,
+				bgName: "customMessageBg",
+				hasDivider: Boolean(text),
+			});
+			this.addChild(block);
+		} catch {
+			return base.call(this);
+		}
+	};
+}

--- a/messages/core-message-blocks.ts
+++ b/messages/core-message-blocks.ts
@@ -64,7 +64,7 @@ function patchCompaction(ctor?: ComponentCtor): void {
 				title: `${tokenStr} tokens`,
 				right: expanded ? undefined : "(Ctrl+O to expand)",
 				body,
-				bgName: "customMessageBg",
+
 				hasDivider: expanded,
 			});
 			this.addChild(block);
@@ -102,7 +102,7 @@ function patchSkill(ctor?: ComponentCtor): void {
 				title: skillName,
 				right: expanded ? undefined : "(Ctrl+O to expand)",
 				body,
-				bgName: "customMessageBg",
+
 				hasDivider: expanded,
 			});
 			this.addChild(block);
@@ -136,7 +136,7 @@ function patchBranch(ctor?: ComponentCtor): void {
 				kind: "Branch",
 				right: expanded ? undefined : "(Ctrl+O to expand)",
 				body,
-				bgName: "customMessageBg",
+
 				hasDivider: expanded,
 			});
 			this.addChild(block);
@@ -202,7 +202,7 @@ function patchCustomMessage(ctor?: ComponentCtor): void {
 				kind: "Custom",
 				title: customType,
 				body,
-				bgName: "customMessageBg",
+
 				hasDivider: Boolean(text),
 			});
 			this.customComponent = block;

--- a/messages/core-message-blocks.ts
+++ b/messages/core-message-blocks.ts
@@ -1,6 +1,6 @@
 import { Markdown } from "@earendil-works/pi-tui";
 import { setFullTheme } from "../theme/theme-extras.js";
-import { boxBg } from "../tool-tags/common.js";
+import { boxBg, boxBgLines } from "../tool-tags/common.js";
 import { renderBoxedMessageBlock } from "./boxed-message-block.js";
 
 const PATCH_FLAG = "__droidCoreMessageBlocksPatched__";
@@ -33,6 +33,17 @@ export function installCoreMessageBlockStyling(ctors: {
 function setMessageBlockBackground(component: any, theme: any): void {
 	if (typeof component?.setBgFn !== "function") return;
 	component.setBgFn((text: string) => boxBg(theme, text, "customMessageBg"));
+}
+
+function withMessageBlockBackground(component: any, theme: any): any {
+	return {
+		invalidate() {
+			if (typeof component?.invalidate === "function") component.invalidate();
+		},
+		render(width: number): string[] {
+			return boxBgLines(theme, component.render(width), "customMessageBg");
+		},
+	};
 }
 
 function createMarkdownBody(text: string, markdownTheme: any, theme: any): (contentWidth: number) => string[] {
@@ -223,8 +234,8 @@ function patchCustomMessage(ctor?: ComponentCtor): void {
 				this.box.clear();
 				this.box.addChild(block);
 			} else {
-				this.customComponent = block;
-				this.addChild(block);
+				this.customComponent = withMessageBlockBackground(block, theme);
+				this.addChild(this.customComponent);
 			}
 		} catch {
 			return base.call(this);

--- a/messages/core-message-blocks.ts
+++ b/messages/core-message-blocks.ts
@@ -140,7 +140,7 @@ function patchBranch(ctor?: ComponentCtor): void {
 	const base = proto.updateDisplay;
 	proto.updateDisplay = function patchedBranchUpdateDisplay(this: any) {
 		const theme = cachedTheme;
-		if (!theme) return base.call(this);
+		if (!theme || this.message == null) return base.call(this);
 
 		setMessageBlockBackground(this, theme);
 		this.clear();

--- a/messages/core-message-blocks.ts
+++ b/messages/core-message-blocks.ts
@@ -205,6 +205,7 @@ function patchCustomMessage(ctor?: ComponentCtor): void {
 				bgName: "customMessageBg",
 				hasDivider: Boolean(text),
 			});
+			this.customComponent = block;
 			this.addChild(block);
 		} catch {
 			return base.call(this);

--- a/messages/core-message-blocks.ts
+++ b/messages/core-message-blocks.ts
@@ -1,4 +1,6 @@
 import { Markdown } from "@earendil-works/pi-tui";
+import { setFullTheme } from "../theme/theme-extras.js";
+import { boxBg } from "../tool-tags/common.js";
 import { renderBoxedMessageBlock } from "./boxed-message-block.js";
 
 const PATCH_FLAG = "__droidCoreMessageBlocksPatched__";
@@ -7,6 +9,7 @@ let cachedTheme: any = null;
 
 export function setCoreMessageBlockTheme(theme: any): void {
 	cachedTheme = theme;
+	setFullTheme(theme);
 }
 
 type ComponentCtor = { prototype?: any };
@@ -25,6 +28,11 @@ export function installCoreMessageBlockStyling(ctors: {
 	patchSkill(ctors.SkillInvocationMessageComponent);
 	patchBranch(ctors.BranchSummaryMessageComponent);
 	patchCustomMessage(ctors.CustomMessageComponent);
+}
+
+function setMessageBlockBackground(component: any, theme: any): void {
+	if (typeof component?.setBgFn !== "function") return;
+	component.setBgFn((text: string) => boxBg(theme, text, "customMessageBg"));
 }
 
 function createMarkdownBody(text: string, markdownTheme: any, theme: any): (contentWidth: number) => string[] {
@@ -46,6 +54,7 @@ function patchCompaction(ctor?: ComponentCtor): void {
 		const tokensBefore = this.message.tokensBefore;
 		if (tokensBefore == null) return base.call(this);
 
+		setMessageBlockBackground(this, theme);
 		this.clear();
 
 		const expanded = Boolean(this.expanded);
@@ -64,7 +73,6 @@ function patchCompaction(ctor?: ComponentCtor): void {
 				title: `${tokenStr} tokens`,
 				right: expanded ? undefined : "(Ctrl+O to expand)",
 				body,
-
 				hasDivider: expanded,
 			});
 			this.addChild(block);
@@ -86,6 +94,7 @@ function patchSkill(ctor?: ComponentCtor): void {
 		const skillName = this.skillBlock.name;
 		if (!skillName) return base.call(this);
 
+		setMessageBlockBackground(this, theme);
 		this.clear();
 
 		const expanded = Boolean(this.expanded);
@@ -102,7 +111,6 @@ function patchSkill(ctor?: ComponentCtor): void {
 				title: skillName,
 				right: expanded ? undefined : "(Ctrl+O to expand)",
 				body,
-
 				hasDivider: expanded,
 			});
 			this.addChild(block);
@@ -121,6 +129,7 @@ function patchBranch(ctor?: ComponentCtor): void {
 		const theme = cachedTheme;
 		if (!theme) return base.call(this);
 
+		setMessageBlockBackground(this, theme);
 		this.clear();
 
 		const expanded = Boolean(this.expanded);
@@ -136,7 +145,6 @@ function patchBranch(ctor?: ComponentCtor): void {
 				kind: "Branch",
 				right: expanded ? undefined : "(Ctrl+O to expand)",
 				body,
-
 				hasDivider: expanded,
 			});
 			this.addChild(block);
@@ -202,11 +210,18 @@ function patchCustomMessage(ctor?: ComponentCtor): void {
 				kind: "Custom",
 				title: customType,
 				body,
-
 				hasDivider: Boolean(text),
 			});
-			this.customComponent = block;
-			this.addChild(block);
+
+			if (this.box && typeof this.box.clear === "function" && typeof this.box.addChild === "function") {
+				setMessageBlockBackground(this.box, theme);
+				this.addChild(this.box);
+				this.box.clear();
+				this.box.addChild(block);
+			} else {
+				this.customComponent = block;
+				this.addChild(block);
+			}
 		} catch {
 			return base.call(this);
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-droid-styling",
-  "version": "2.5.4",
+  "version": "2.6.0",
   "description": "Custom UI styling for Pi: compact startup UI, boxed editor, tool badges, message prefixes, and footer stats.",
   "type": "module",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:working-message": "node scripts/working-message-config-smoke.mjs",
     "test:startup-resources": "node scripts/startup-resources-smoke.mjs",
     "test:theme-extras": "node scripts/theme-extras-smoke.mjs",
-    "test:user-zone-style": "node scripts/user-zone-style-smoke.mjs"
+    "test:user-zone-style": "node scripts/user-zone-style-smoke.mjs",
+    "test:core-message-blocks": "node scripts/core-message-blocks-smoke.mjs"
   },
   "pi": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-droid-styling",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Custom UI styling for Pi: compact startup UI, boxed editor, tool badges, message prefixes, and footer stats.",
   "type": "module",
   "main": "index.ts",

--- a/scripts/core-message-blocks-smoke.mjs
+++ b/scripts/core-message-blocks-smoke.mjs
@@ -12,6 +12,9 @@ const themeSourcePath = join(workDir, "smoke-theme.json");
 const stubPath = join(workDir, "node-stubs.d.ts");
 const tsc = join(repoRoot, "node_modules", "typescript", "lib", "tsc.js");
 let importCounter = 0;
+const PAGE_BG = "\x1b[48;2;1;2;3m";
+const CUSTOM_MESSAGE_BG = "\x1b[48;5;236m";
+
 
 function assert(condition, message) {
 	if (!condition) throw new Error(message);
@@ -23,6 +26,11 @@ function stripAnsi(text) {
 
 function resetCoreMessageBlockPatchFlag() {
 	delete globalThis.__droidCoreMessageBlocksPatched__;
+}
+
+function assertUsesPageBackground(lines, label) {
+	assert(lines.some((line) => line.includes(PAGE_BG)), `${label} should use common page background`);
+	assert(!lines.some((line) => line.includes(CUSTOM_MESSAGE_BG)), `${label} should not use brighter customMessageBg`);
 }
 
 function prepareWorkDir() {
@@ -134,7 +142,6 @@ async function runBoxedMessageBlockSmoke() {
 		title: "plan",
 		right: "(Ctrl+O to expand)",
 		body: () => [],
-
 		hasDivider: false,
 	});
 	const collapsedLines = collapsedBlock.render(60);
@@ -144,8 +151,8 @@ async function runBoxedMessageBlockSmoke() {
 	assert(collapsedStripped[0]?.startsWith("┌"), "collapsed block should start with top border");
 	assert(collapsedStripped[1]?.includes("➔ Skill | plan"), "collapsed block should have formatted title");
 	assert(collapsedStripped[1]?.includes("(Ctrl+O to expand)"), "collapsed block should have right hint");
-	assert(!collapsedLines.some((line) => line.includes("\x1b[48;5;236m")), "message block child should not apply background - parent Box handles it");
-	assert(!collapsedLines.some((line) => line.includes("\x1b[48;2;1;2;3m")), "message blocks should not use pageBg behind border lines");
+	assert(!collapsedLines.some((line) => line.includes(CUSTOM_MESSAGE_BG)), "message block child should not apply background - parent Box handles it");
+	assert(!collapsedLines.some((line) => line.includes(PAGE_BG)), "message block child should not apply pageBg - parent Box handles it");
 	assert(collapsedStripped[2]?.startsWith("└"), "collapsed block should end with bottom border");
 	console.log("boxed message block collapsed smoke ok");
 
@@ -154,7 +161,6 @@ async function runBoxedMessageBlockSmoke() {
 		kind: "Compaction",
 		title: "123,456 tokens",
 		body: (contentWidth) => ["Compacted summary line 1", "Compacted summary line 2"],
-
 		hasDivider: true,
 	});
 	const expandedLines = expandedBlock.render(60);
@@ -173,7 +179,6 @@ async function runBoxedMessageBlockSmoke() {
 	const noTitleBlock = renderBoxedMessageBlock(theme, {
 		kind: "Branch",
 		body: () => ["Branch summary content"],
-
 		hasDivider: true,
 	});
 	const noTitleLines = noTitleBlock.render(60);
@@ -203,6 +208,35 @@ async function runInstallerSmoke() {
 	console.log("installer missing-components smoke ok");
 }
 
+async function runBoxBackedComponentBackgroundSmoke() {
+	resetCoreMessageBlockPatchFlag();
+	const {
+		BranchSummaryMessageComponent,
+		CompactionSummaryMessageComponent,
+		SkillInvocationMessageComponent,
+	} = await import("@earendil-works/pi-coding-agent");
+	const { installCoreMessageBlockStyling, setCoreMessageBlockTheme } = await importBuilt("messages/core-message-blocks.js");
+	const theme = makeTheme();
+
+	setCoreMessageBlockTheme(theme);
+	installCoreMessageBlockStyling({
+		BranchSummaryMessageComponent,
+		CompactionSummaryMessageComponent,
+		SkillInvocationMessageComponent,
+	});
+
+	const components = [
+		["compaction", new CompactionSummaryMessageComponent({ tokensBefore: 123456, summary: "summary" }, undefined)],
+		["skill", new SkillInvocationMessageComponent({ name: "plan", content: "body" }, undefined)],
+		["branch", new BranchSummaryMessageComponent({ summary: "branch summary" }, undefined)],
+	];
+
+	for (const [label, component] of components) {
+		assertUsesPageBackground(component.render(60), label);
+	}
+	console.log("box-backed component background smoke ok");
+}
+
 async function runCustomMessageComponentSmoke() {
 	resetCoreMessageBlockPatchFlag();
 	const { CustomMessageComponent } = await import("@earendil-works/pi-coding-agent");
@@ -213,6 +247,7 @@ async function runCustomMessageComponentSmoke() {
 	installCoreMessageBlockStyling({ CustomMessageComponent });
 
 	const fallback = new CustomMessageComponent({ customType: "probe", content: "hello" }, undefined);
+	assertUsesPageBackground(fallback.render(60), "custom fallback");
 	const first = fallback.render(60).map(stripAnsi);
 	fallback.rebuild();
 	const second = fallback.render(60).map(stripAnsi);
@@ -252,7 +287,6 @@ async function runPatchedComponentSmoke() {
 			title: `${tokenStr} tokens`,
 			right: expanded ? undefined : "(Ctrl+O to expand)",
 			body,
-	
 			hasDivider: expanded,
 		});
 		return block.render(80).map(stripAnsi);
@@ -284,7 +318,6 @@ async function runPatchedComponentSmoke() {
 			title: skillName,
 			right: expanded ? undefined : "(Ctrl+O to expand)",
 			body,
-	
 			hasDivider: expanded,
 		});
 		return block.render(80).map(stripAnsi);
@@ -304,6 +337,7 @@ async function main() {
 	compileChangedSurface();
 	await runBoxedMessageBlockSmoke();
 	await runInstallerSmoke();
+	await runBoxBackedComponentBackgroundSmoke();
 	await runCustomMessageComponentSmoke();
 	await runPatchedComponentSmoke();
 	console.log("core-message-blocks smoke ok");

--- a/scripts/core-message-blocks-smoke.mjs
+++ b/scripts/core-message-blocks-smoke.mjs
@@ -237,6 +237,43 @@ async function runBoxBackedComponentBackgroundSmoke() {
 	console.log("box-backed component background smoke ok");
 }
 
+async function runBranchNullGuardSmoke() {
+	resetCoreMessageBlockPatchFlag();
+	const { installCoreMessageBlockStyling, setCoreMessageBlockTheme } = await importBuilt("messages/core-message-blocks.js");
+	const theme = makeTheme();
+	let baseCalls = 0;
+
+	class BranchSummaryMessageComponent {
+		constructor() {
+			this.message = null;
+			this.children = ["native"];
+		}
+
+		updateDisplay() {
+			baseCalls += 1;
+			this.baseRendered = true;
+		}
+
+		clear() {
+			this.children = [];
+		}
+
+		addChild(component) {
+			this.children.push(component);
+		}
+	}
+
+	setCoreMessageBlockTheme(theme);
+	installCoreMessageBlockStyling({ BranchSummaryMessageComponent });
+
+	const branch = new BranchSummaryMessageComponent();
+	branch.updateDisplay();
+	assert(baseCalls === 1, `branch null message should call base updateDisplay, got ${baseCalls}`);
+	assert(branch.baseRendered === true, "branch null message should use native base display");
+	assert(branch.children.length === 1 && branch.children[0] === "native", "branch null message should not clear native children");
+	console.log("branch null message guard smoke ok");
+}
+
 async function runCustomMessageComponentSmoke() {
 	resetCoreMessageBlockPatchFlag();
 	const { CustomMessageComponent } = await import("@earendil-works/pi-coding-agent");
@@ -369,6 +406,7 @@ async function main() {
 	await runBoxedMessageBlockSmoke();
 	await runInstallerSmoke();
 	await runBoxBackedComponentBackgroundSmoke();
+	await runBranchNullGuardSmoke();
 	await runCustomMessageComponentSmoke();
 	await runPatchedComponentSmoke();
 	console.log("core-message-blocks smoke ok");

--- a/scripts/core-message-blocks-smoke.mjs
+++ b/scripts/core-message-blocks-smoke.mjs
@@ -20,6 +20,10 @@ function stripAnsi(text) {
 	return String(text).replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, "").replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "");
 }
 
+function resetCoreMessageBlockPatchFlag() {
+	delete globalThis.__droidCoreMessageBlocksPatched__;
+}
+
 function prepareWorkDir() {
 	rmSync(workDir, { recursive: true, force: true });
 	mkdirSync(buildDir, { recursive: true });
@@ -170,6 +174,7 @@ async function runBoxedMessageBlockSmoke() {
 }
 
 async function runInstallerSmoke() {
+	resetCoreMessageBlockPatchFlag();
 	const { installCoreMessageBlockStyling, setCoreMessageBlockTheme } = await importBuilt("messages/core-message-blocks.js");
 	const theme = makeTheme();
 
@@ -186,6 +191,37 @@ async function runInstallerSmoke() {
 	// Test that missing components don't throw
 	installCoreMessageBlockStyling({});
 	console.log("installer missing-components smoke ok");
+}
+
+async function runCustomMessageComponentSmoke() {
+	resetCoreMessageBlockPatchFlag();
+	const { CustomMessageComponent } = await import("@earendil-works/pi-coding-agent");
+	const { installCoreMessageBlockStyling, setCoreMessageBlockTheme } = await importBuilt("messages/core-message-blocks.js");
+	const theme = makeTheme();
+
+	setCoreMessageBlockTheme(theme);
+	installCoreMessageBlockStyling({ CustomMessageComponent });
+
+	const fallback = new CustomMessageComponent({ customType: "probe", content: "hello" }, undefined);
+	const first = fallback.render(60).map(stripAnsi);
+	fallback.rebuild();
+	const second = fallback.render(60).map(stripAnsi);
+	const firstCount = first.filter((line) => line.includes("➔ Custom | probe")).length;
+	const secondCount = second.filter((line) => line.includes("➔ Custom | probe")).length;
+	assert(firstCount === 1, `custom fallback should render one boxed block initially, got ${firstCount}`);
+	assert(secondCount === 1, `custom fallback should not duplicate after rebuild, got ${secondCount}`);
+	assert(second.length === first.length, `custom fallback rebuild should keep line count stable, before=${first.length} after=${second.length}`);
+	console.log("custom message fallback rebuild smoke ok");
+
+	const customRendered = { render: () => ["custom renderer output"] };
+	const rendered = new CustomMessageComponent({ customType: "rendered", content: "ignored" }, () => customRendered);
+	const renderedLines = rendered.render(60).map(stripAnsi);
+	rendered.rebuild();
+	const rerenderedLines = rendered.render(60).map(stripAnsi);
+	assert(rerenderedLines.some((line) => line.includes("custom renderer output")), "custom renderer output should be preserved");
+	assert(!rerenderedLines.some((line) => line.includes("➔ Custom | rendered")), "custom renderer output should not be wrapped by fallback box");
+	assert(rerenderedLines.length === renderedLines.length, "custom renderer rebuild should keep line count stable");
+	console.log("custom message renderer passthrough smoke ok");
 }
 
 async function runPatchedComponentSmoke() {
@@ -258,6 +294,7 @@ async function main() {
 	compileChangedSurface();
 	await runBoxedMessageBlockSmoke();
 	await runInstallerSmoke();
+	await runCustomMessageComponentSmoke();
 	await runPatchedComponentSmoke();
 	console.log("core-message-blocks smoke ok");
 }

--- a/scripts/core-message-blocks-smoke.mjs
+++ b/scripts/core-message-blocks-smoke.mjs
@@ -8,6 +8,7 @@ import { pathToFileURL } from "node:url";
 const repoRoot = process.cwd();
 const workDir = join(repoRoot, ".pi", "core-message-blocks-smoke");
 const buildDir = join(workDir, "build");
+const themeSourcePath = join(workDir, "smoke-theme.json");
 const stubPath = join(workDir, "node-stubs.d.ts");
 const tsc = join(repoRoot, "node_modules", "typescript", "lib", "tsc.js");
 let importCounter = 0;
@@ -28,6 +29,11 @@ function prepareWorkDir() {
 	rmSync(workDir, { recursive: true, force: true });
 	mkdirSync(buildDir, { recursive: true });
 	writeFileSync(join(buildDir, "package.json"), "{\"type\":\"module\"}\n", "utf8");
+	writeFileSync(themeSourcePath, JSON.stringify({
+		name: "droid-smoke",
+		vars: { bg: "#010203", customMessageBg: "#1f2328" },
+		export: { pageBg: "bg" },
+	}) + "\n", "utf8");
 	writeFileSync(stubPath, `declare module "fs" {
 	export const existsSync: (path: string) => boolean;
 	export const mkdirSync: (path: string, options?: unknown) => unknown;
@@ -98,6 +104,8 @@ async function importBuilt(relativePath) {
 
 function makeTheme() {
 	return {
+		name: "droid-smoke",
+		sourcePath: themeSourcePath,
 		fg: (color, text) => {
 			if (color === "dim") return `\x1b[2m${text}\x1b[22m`;
 			if (color === "bashMode") return `\x1b[36m${text}\x1b[39m`;
@@ -126,7 +134,7 @@ async function runBoxedMessageBlockSmoke() {
 		title: "plan",
 		right: "(Ctrl+O to expand)",
 		body: () => [],
-		bgName: "customMessageBg",
+
 		hasDivider: false,
 	});
 	const collapsedLines = collapsedBlock.render(60);
@@ -136,6 +144,8 @@ async function runBoxedMessageBlockSmoke() {
 	assert(collapsedStripped[0]?.startsWith("┌"), "collapsed block should start with top border");
 	assert(collapsedStripped[1]?.includes("➔ Skill | plan"), "collapsed block should have formatted title");
 	assert(collapsedStripped[1]?.includes("(Ctrl+O to expand)"), "collapsed block should have right hint");
+	assert(!collapsedLines.some((line) => line.includes("\x1b[48;5;236m")), "message block child should not apply background - parent Box handles it");
+	assert(!collapsedLines.some((line) => line.includes("\x1b[48;2;1;2;3m")), "message blocks should not use pageBg behind border lines");
 	assert(collapsedStripped[2]?.startsWith("└"), "collapsed block should end with bottom border");
 	console.log("boxed message block collapsed smoke ok");
 
@@ -144,7 +154,7 @@ async function runBoxedMessageBlockSmoke() {
 		kind: "Compaction",
 		title: "123,456 tokens",
 		body: (contentWidth) => ["Compacted summary line 1", "Compacted summary line 2"],
-		bgName: "customMessageBg",
+
 		hasDivider: true,
 	});
 	const expandedLines = expandedBlock.render(60);
@@ -163,7 +173,7 @@ async function runBoxedMessageBlockSmoke() {
 	const noTitleBlock = renderBoxedMessageBlock(theme, {
 		kind: "Branch",
 		body: () => ["Branch summary content"],
-		bgName: "customMessageBg",
+
 		hasDivider: true,
 	});
 	const noTitleLines = noTitleBlock.render(60);
@@ -242,7 +252,7 @@ async function runPatchedComponentSmoke() {
 			title: `${tokenStr} tokens`,
 			right: expanded ? undefined : "(Ctrl+O to expand)",
 			body,
-			bgName: "customMessageBg",
+	
 			hasDivider: expanded,
 		});
 		return block.render(80).map(stripAnsi);
@@ -274,7 +284,7 @@ async function runPatchedComponentSmoke() {
 			title: skillName,
 			right: expanded ? undefined : "(Ctrl+O to expand)",
 			body,
-			bgName: "customMessageBg",
+	
 			hasDivider: expanded,
 		});
 		return block.render(80).map(stripAnsi);

--- a/scripts/core-message-blocks-smoke.mjs
+++ b/scripts/core-message-blocks-smoke.mjs
@@ -251,8 +251,8 @@ async function runCustomMessageComponentSmoke() {
 	const first = fallback.render(60).map(stripAnsi);
 	fallback.rebuild();
 	const second = fallback.render(60).map(stripAnsi);
-	const firstCount = first.filter((line) => line.includes("➔ Custom | probe")).length;
-	const secondCount = second.filter((line) => line.includes("➔ Custom | probe")).length;
+	const firstCount = first.filter((line) => line.includes("⊟ Custom | probe")).length;
+	const secondCount = second.filter((line) => line.includes("⊟ Custom | probe")).length;
 	assert(firstCount === 1, `custom fallback should render one boxed block initially, got ${firstCount}`);
 	assert(secondCount === 1, `custom fallback should not duplicate after rebuild, got ${secondCount}`);
 	assert(second.length === first.length, `custom fallback rebuild should keep line count stable, before=${first.length} after=${second.length}`);
@@ -264,7 +264,7 @@ async function runCustomMessageComponentSmoke() {
 	rendered.rebuild();
 	const rerenderedLines = rendered.render(60).map(stripAnsi);
 	assert(rerenderedLines.some((line) => line.includes("custom renderer output")), "custom renderer output should be preserved");
-	assert(!rerenderedLines.some((line) => line.includes("➔ Custom | rendered")), "custom renderer output should not be wrapped by fallback box");
+	assert(!rerenderedLines.some((line) => line.includes("⊟ Custom | rendered")), "custom renderer output should not be wrapped by fallback box");
 	assert(rerenderedLines.length === renderedLines.length, "custom renderer rebuild should keep line count stable");
 	console.log("custom message renderer passthrough smoke ok");
 }
@@ -287,6 +287,7 @@ async function runPatchedComponentSmoke() {
 			title: `${tokenStr} tokens`,
 			right: expanded ? undefined : "(Ctrl+O to expand)",
 			body,
+			icon: "⊟",
 			hasDivider: expanded,
 		});
 		return block.render(80).map(stripAnsi);
@@ -318,13 +319,14 @@ async function runPatchedComponentSmoke() {
 			title: skillName,
 			right: expanded ? undefined : "(Ctrl+O to expand)",
 			body,
+			icon: "⊟",
 			hasDivider: expanded,
 		});
 		return block.render(80).map(stripAnsi);
 	}
 
 	const skillCollapsed = simulatePatchedSkill(false, "plan", "Plan content");
-	assert(skillCollapsed[1]?.includes("➔ Skill | plan"), "collapsed skill should show skill name in title");
+	assert(skillCollapsed[1]?.includes("⊟ Skill | plan"), "collapsed skill should show skill name in title");
 	console.log("patched skill collapsed smoke ok");
 
 	const skillExpanded = simulatePatchedSkill(true, "plan", "Plan content");

--- a/scripts/core-message-blocks-smoke.mjs
+++ b/scripts/core-message-blocks-smoke.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = process.cwd();
+const workDir = join(repoRoot, ".pi", "core-message-blocks-smoke");
+const buildDir = join(workDir, "build");
+const stubPath = join(workDir, "node-stubs.d.ts");
+const tsc = join(repoRoot, "node_modules", "typescript", "lib", "tsc.js");
+let importCounter = 0;
+
+function assert(condition, message) {
+	if (!condition) throw new Error(message);
+}
+
+function stripAnsi(text) {
+	return String(text).replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, "").replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "");
+}
+
+function prepareWorkDir() {
+	rmSync(workDir, { recursive: true, force: true });
+	mkdirSync(buildDir, { recursive: true });
+	writeFileSync(join(buildDir, "package.json"), "{\"type\":\"module\"}\n", "utf8");
+	writeFileSync(stubPath, `declare module "fs" {
+	export const existsSync: (path: string) => boolean;
+	export const mkdirSync: (path: string, options?: unknown) => unknown;
+	export const readFileSync: (path: string, encoding: string) => string;
+}
+declare module "node:fs" {
+	export const existsSync: (path: string) => boolean;
+	export const mkdirSync: (path: string, options?: unknown) => unknown;
+	export const readFileSync: (path: string, encoding: string) => string;
+}
+declare module "path" {
+	export const dirname: (path: string) => string;
+	export const join: (...parts: string[]) => string;
+	export const resolve: (...parts: string[]) => string;
+}
+declare module "node:path" {
+	export const dirname: (path: string) => string;
+	export const join: (...parts: string[]) => string;
+	export const resolve: (...parts: string[]) => string;
+}
+declare module "os" {
+	export const homedir: () => string;
+}
+declare module "node:os" {
+	export const homedir: () => string;
+}
+declare module "node:url" {
+	export const fileURLToPath: (url: string | URL) => string;
+}
+declare const process: any;
+declare type Buffer = any;
+declare const Buffer: any;
+`, "utf8");
+}
+
+function compileChangedSurface() {
+	if (!existsSync(tsc)) throw new Error("typescript is not installed; run npm install before npm run test:core-message-blocks");
+	const result = spawnSync(process.execPath, [
+		tsc,
+		"--outDir", buildDir,
+		"--rootDir", repoRoot,
+		"--module", "NodeNext",
+		"--moduleResolution", "NodeNext",
+		"--target", "ES2022",
+		"--skipLibCheck",
+		"--noImplicitAny", "false",
+		stubPath,
+		"messages/boxed-message-block.ts",
+		"messages/core-message-blocks.ts",
+		"tool-tags/common.ts",
+		"render-budget.ts",
+		"theme/ansi.ts",
+		"theme/theme-extras.ts",
+		"performance/profiler.ts",
+	], { cwd: repoRoot, encoding: "utf8" });
+	if (result.status !== 0) {
+		process.stderr.write(result.stdout || "");
+		process.stderr.write(result.stderr || "");
+		throw new Error(`TypeScript compile failed with code ${result.status}`);
+	}
+	console.log("tsc focused ok");
+}
+
+async function importBuilt(relativePath) {
+	importCounter += 1;
+	return import(`${pathToFileURL(join(buildDir, relativePath)).href}?smoke=${importCounter}`);
+}
+
+function makeTheme() {
+	return {
+		fg: (color, text) => {
+			if (color === "dim") return `\x1b[2m${text}\x1b[22m`;
+			if (color === "bashMode") return `\x1b[36m${text}\x1b[39m`;
+			if (color === "customMessageText") return `\x1b[37m${text}\x1b[39m`;
+			return text;
+		},
+		bg: (color, text) => {
+			if (color === "customMessageBg") return `\x1b[48;5;236m${text}\x1b[49m`;
+			return text;
+		},
+		getBgAnsi: (color) => {
+			if (color === "customMessageBg") return "\x1b[48;5;236m";
+			return "";
+		},
+		bold: (text) => `\x1b[1m${text}\x1b[22m`,
+	};
+}
+
+async function runBoxedMessageBlockSmoke() {
+	const { renderBoxedMessageBlock } = await importBuilt("messages/boxed-message-block.js");
+	const theme = makeTheme();
+
+	// Test collapsed block with right hint
+	const collapsedBlock = renderBoxedMessageBlock(theme, {
+		kind: "Skill",
+		title: "plan",
+		right: "(Ctrl+O to expand)",
+		body: () => [],
+		bgName: "customMessageBg",
+		hasDivider: false,
+	});
+	const collapsedLines = collapsedBlock.render(60);
+	const collapsedStripped = collapsedLines.map(stripAnsi);
+
+	assert(collapsedLines.length === 3, `collapsed block should have 3 lines (top, title, bottom), got ${collapsedLines.length}`);
+	assert(collapsedStripped[0]?.startsWith("┌"), "collapsed block should start with top border");
+	assert(collapsedStripped[1]?.includes("➔ Skill | plan"), "collapsed block should have formatted title");
+	assert(collapsedStripped[1]?.includes("(Ctrl+O to expand)"), "collapsed block should have right hint");
+	assert(collapsedStripped[2]?.startsWith("└"), "collapsed block should end with bottom border");
+	console.log("boxed message block collapsed smoke ok");
+
+	// Test expanded block with divider and body
+	const expandedBlock = renderBoxedMessageBlock(theme, {
+		kind: "Compaction",
+		title: "123,456 tokens",
+		body: (contentWidth) => ["Compacted summary line 1", "Compacted summary line 2"],
+		bgName: "customMessageBg",
+		hasDivider: true,
+	});
+	const expandedLines = expandedBlock.render(60);
+	const expandedStripped = expandedLines.map(stripAnsi);
+
+	assert(expandedLines.length === 6, `expanded block should have 6 lines (top, title, divider, body1, body2, bottom), got ${expandedLines.length}`);
+	assert(expandedStripped[0]?.startsWith("┌"), "expanded block should start with top border");
+	assert(expandedStripped[1]?.includes("➔ Compaction | 123,456 tokens"), "expanded block should have formatted title");
+	assert(expandedStripped[2]?.includes("─"), "expanded block should have divider");
+	assert(expandedStripped[3]?.includes("Compacted summary line 1"), "expanded block should have body line 1");
+	assert(expandedStripped[4]?.includes("Compacted summary line 2"), "expanded block should have body line 2");
+	assert(expandedStripped[5]?.startsWith("└"), "expanded block should end with bottom border");
+	console.log("boxed message block expanded smoke ok");
+
+	// Test block without title
+	const noTitleBlock = renderBoxedMessageBlock(theme, {
+		kind: "Branch",
+		body: () => ["Branch summary content"],
+		bgName: "customMessageBg",
+		hasDivider: true,
+	});
+	const noTitleLines = noTitleBlock.render(60);
+	const noTitleStripped = noTitleLines.map(stripAnsi);
+	assert(noTitleStripped[1]?.includes("➔ Branch"), "block without title should show kind only");
+	assert(!noTitleStripped[1]?.includes("|"), "block without title should not have pipe separator");
+	console.log("boxed message block no-title smoke ok");
+}
+
+async function runInstallerSmoke() {
+	const { installCoreMessageBlockStyling, setCoreMessageBlockTheme } = await importBuilt("messages/core-message-blocks.js");
+	const theme = makeTheme();
+
+	// Test that installer can be called without throwing
+	setCoreMessageBlockTheme(theme);
+	installCoreMessageBlockStyling({
+		CompactionSummaryMessageComponent: { prototype: {} },
+		SkillInvocationMessageComponent: { prototype: {} },
+		BranchSummaryMessageComponent: { prototype: {} },
+		CustomMessageComponent: { prototype: {} },
+	});
+	console.log("installer no-throw smoke ok");
+
+	// Test that missing components don't throw
+	installCoreMessageBlockStyling({});
+	console.log("installer missing-components smoke ok");
+}
+
+async function runPatchedComponentSmoke() {
+	// Reset the global patch flag by creating a new module instance
+	// Since we can't easily reset Symbol.for, we'll test the patch logic directly
+	const { renderBoxedMessageBlock } = await importBuilt("messages/boxed-message-block.js");
+	const theme = makeTheme();
+
+	// Simulate what a patched component would do
+	function simulatePatchedCompaction(expanded, tokensBefore, summary) {
+		const tokenStr = tokensBefore.toLocaleString();
+		const body = expanded && summary
+			? (contentWidth) => [summary]
+			: () => [];
+
+		const block = renderBoxedMessageBlock(theme, {
+			kind: "Compaction",
+			title: `${tokenStr} tokens`,
+			right: expanded ? undefined : "(Ctrl+O to expand)",
+			body,
+			bgName: "customMessageBg",
+			hasDivider: expanded,
+		});
+		return block.render(80).map(stripAnsi);
+	}
+
+	// Test collapsed compaction
+	const collapsed = simulatePatchedCompaction(false, 123456, "This is a long summary");
+	assert(collapsed.length === 3, `collapsed compaction should have 3 lines, got ${collapsed.length}`);
+	assert(collapsed[1]?.includes("123,456 tokens"), "collapsed compaction should show token count in title");
+	assert(collapsed[1]?.includes("(Ctrl+O to expand)"), "collapsed compaction should show expand hint");
+	console.log("patched compaction collapsed smoke ok");
+
+	// Test expanded compaction
+	const expanded = simulatePatchedCompaction(true, 123456, "This is a long summary");
+	assert(expanded.length === 5, `expanded compaction should have 5 lines, got ${expanded.length}`);
+	assert(expanded[1]?.includes("123,456 tokens"), "expanded compaction should show token count in title");
+	assert(!expanded[1]?.includes("(Ctrl+O to expand)"), "expanded compaction should not show expand hint");
+	assert(expanded[3]?.includes("This is a long summary"), "expanded compaction should show summary");
+	console.log("patched compaction expanded smoke ok");
+
+	// Simulate patched skill
+	function simulatePatchedSkill(expanded, skillName, content) {
+		const body = expanded && content
+			? (contentWidth) => [content]
+			: () => [];
+
+		const block = renderBoxedMessageBlock(theme, {
+			kind: "Skill",
+			title: skillName,
+			right: expanded ? undefined : "(Ctrl+O to expand)",
+			body,
+			bgName: "customMessageBg",
+			hasDivider: expanded,
+		});
+		return block.render(80).map(stripAnsi);
+	}
+
+	const skillCollapsed = simulatePatchedSkill(false, "plan", "Plan content");
+	assert(skillCollapsed[1]?.includes("➔ Skill | plan"), "collapsed skill should show skill name in title");
+	console.log("patched skill collapsed smoke ok");
+
+	const skillExpanded = simulatePatchedSkill(true, "plan", "Plan content");
+	assert(skillExpanded[3]?.includes("Plan content"), "expanded skill should show content");
+	console.log("patched skill expanded smoke ok");
+}
+
+async function main() {
+	prepareWorkDir();
+	compileChangedSurface();
+	await runBoxedMessageBlockSmoke();
+	await runInstallerSmoke();
+	await runPatchedComponentSmoke();
+	console.log("core-message-blocks smoke ok");
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/scripts/core-message-blocks-smoke.mjs
+++ b/scripts/core-message-blocks-smoke.mjs
@@ -258,6 +258,35 @@ async function runCustomMessageComponentSmoke() {
 	assert(second.length === first.length, `custom fallback rebuild should keep line count stable, before=${first.length} after=${second.length}`);
 	console.log("custom message fallback rebuild smoke ok");
 
+	resetCoreMessageBlockPatchFlag();
+	class NoBoxCustomMessageComponent {
+		constructor(message) {
+			this.message = message;
+			this.children = [];
+			this._expanded = false;
+			this.rebuild();
+		}
+		rebuild() {}
+		addChild(component) {
+			this.children.push(component);
+		}
+		removeChild(component) {
+			this.children = this.children.filter((child) => child !== component);
+		}
+		render(width) {
+			return this.children.flatMap((child) => child.render(width));
+		}
+	}
+	installCoreMessageBlockStyling({ CustomMessageComponent: NoBoxCustomMessageComponent });
+	const noBox = new NoBoxCustomMessageComponent({ customType: "nobox", content: "hello" });
+	assertUsesPageBackground(noBox.render(60), "custom no-box fallback");
+	const noBoxFirst = noBox.render(60).map(stripAnsi);
+	noBox.rebuild();
+	const noBoxSecond = noBox.render(60).map(stripAnsi);
+	assert(noBoxFirst.filter((line) => line.includes("⊟ Custom | nobox")).length === 1, "custom no-box fallback should render one boxed block initially");
+	assert(noBoxSecond.filter((line) => line.includes("⊟ Custom | nobox")).length === 1, "custom no-box fallback should not duplicate after rebuild");
+	console.log("custom message no-box fallback background smoke ok");
+
 	const customRendered = { render: () => ["custom renderer output"] };
 	const rendered = new CustomMessageComponent({ customType: "rendered", content: "ignored" }, () => customRendered);
 	const renderedLines = rendered.render(60).map(stripAnsi);

--- a/tool-tags/common.ts
+++ b/tool-tags/common.ts
@@ -319,7 +319,7 @@ export function boxBg(theme: any, text: string, bgName = "toolSuccessBg"): strin
 	return themeBg(theme, bgName, text);
 }
 
-function boxBgLines(theme: any, lines: string[], bgName = "toolSuccessBg"): string[] {
+export function boxBgLines(theme: any, lines: string[], bgName = "toolSuccessBg"): string[] {
 	return lines.map((line) => boxBg(theme, line, bgName));
 }
 
@@ -333,7 +333,7 @@ function padVisibleRight(text: string, width: number): string {
 	return `${text}${" ".repeat(Math.max(0, width - safeVisibleWidth(text)))}`;
 }
 
-function boxLineWithRight(theme: any, left: string, right: string, width: number): string {
+export function boxLineWithRight(theme: any, left: string, right: string, width: number): string {
 	const renderedWidth = boxWidth(width);
 	const contentWidth = boxInnerWidth(renderedWidth);
 	const divider = ` ${boxText(theme, "|")} `;
@@ -375,7 +375,7 @@ export function boxLine(theme: any, content: string, width: number): string {
 	return `${boxFrameText(theme, BOX_VERTICAL)}${sidePad}${truncated}${fill}${sidePad}${boxFrameText(theme, BOX_VERTICAL)}`;
 }
 
-function boxInsetDivider(theme: any, width: number): string {
+export function boxInsetDivider(theme: any, width: number): string {
 	const renderedWidth = boxWidth(width);
 	const lineWidth = boxInnerWidth(renderedWidth);
 	const sidePad = " ".repeat(BOX_SIDE_PADDING);


### PR DESCRIPTION
## Summary
- Style Pi core special message blocks with boxed rendering
- Fix custom fallback rebuild duplication
- Align special message backgrounds with the page surface
- Use ⊟ title icon for special message blocks
- Bump version to 2.6.1

## Verification
- npm run test:core-message-blocks
- npm run test:user-zone-style