### PR TITLE
feat: use welcome-screen block banner for startup logo

### DIFF
--- a/startup-ui.ts
+++ b/startup-ui.ts
@@ -19,10 +19,10 @@ const SYSTEM_CONTEXT_TYPE_WIDTH = safeVisibleWidth("System & Context");
 const SYSTEM_CONTEXT_METRIC_WIDTH = safeVisibleWidth("Words/Lines");
 const RESOURCE_ROW_GAP = "  ·  ";
 const PI_ASCII_LOGO = [
-	"┏━━━┓ ┏━┓",
-	"┃ _ ┃ ┃ ┃",
-	"┣━━━┛ ┃ ┃",
-	"┗━┛   ┗━┛",
+	"█████████",
+	"███   ███",
+	"██████   ███",
+	"███      ███",
 ] as const;
 
 let activeTheme: ThemeLike | undefined;


### PR DESCRIPTION
## Summary
- Replace the compact box-drawing startup logo with the denser block-banner from `@pi-kaush/pi-welcome-screen`.
- Keep the existing droid compact header layout (title, hints, status) and resource panels unchanged.
- Logo glyphs are painted with the active Pi theme accent (`theme.fg("accent", ...)`), so they follow whatever theme is selected (for example `onedark-pro` or other themes from `pi-themes`). No hard-coded logo colors.

## Test plan
- [ ] `/reload` or restart Pi with `pi-droid-styling` enabled
- [ ] Confirm the startup header shows the denser banner logo
- [ ] Switch themes (for example `/theme`) and confirm the logo accent color updates with the active theme
- [ ] Confirm Resources / System & Context / Available Tools still match the current droid startup UI