### PR TITLE
feat: claude-code-style startup header with Pi mark, real commands, session info

### DIFF
--- a/startup-ui.ts
+++ b/startup-ui.ts
@@ -18,12 +18,66 @@ const STARTUP_PANEL_SIDE_PADDING = 2;
 const SYSTEM_CONTEXT_TYPE_WIDTH = safeVisibleWidth("System & Context");
 const SYSTEM_CONTEXT_METRIC_WIDTH = safeVisibleWidth("Words/Lines");
 const RESOURCE_ROW_GAP = "  ·  ";
-const PI_ASCII_LOGO = [
-	"┏━━━┓ ┏━┓",
-	"┃ _ ┃ ┃ ┃",
-	"┣━━━┛ ┃ ┃",
-	"┗━┛   ┗━┛",
+const PI_CLAUDE_LOGO = [
+	"            ",
+	"            ",
+	"█████████   ",
+	"███   ███   ",
+	"██████   ███",
+	"███      ███",
+	"            ",
 ] as const;
+
+type StartupInfo = {
+	model: string;
+	effort: string;
+	cwd: string;
+	tipCommands: string[];
+};
+
+const BUILTIN_SLASH_COMMANDS = [
+	"settings", "model", "scoped-models", "export", "import", "share",
+	"copy", "name", "session", "changelog", "hotkeys", "fork",
+	"clone", "tree", "trust", "login", "logout", "new",
+	"compact", "resume", "reload", "quit", "theme",
+] as const;
+
+function collectSlashCommandNames(skills: { name: string }[], templates: { name: string }[]): string[] {
+	const names = new Set<string>(BUILTIN_SLASH_COMMANDS);
+	for (const skill of skills) if (skill.name) names.add(skill.name);
+	for (const template of templates) if (template.name) names.add(template.name);
+	return [...names].sort();
+}
+
+function pickSlashCommandTips(available: string[], count = 3): string[] {
+	const fixed = ["use-default-tui"];
+	const exclude = new Set([...fixed, "use-claude-code-tui"]);
+	const pool = available.filter((n) => !exclude.has(n));
+	for (let i = pool.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		[pool[i], pool[j]] = [pool[j], pool[i]];
+	}
+	return [...fixed, ...pool.slice(0, count)].map((n) => (n.startsWith("/") ? n : `/${n}`));
+}
+
+function formatModelLabel(scopedModels: any[]): string {
+	if (scopedModels.length === 0) return "Default model";
+	const m = scopedModels[0]?.model;
+	if (!m?.id) return "Default model";
+	return m.provider ? `${m.provider}/${m.id}` : m.id;
+}
+
+function formatCwd(cwd: string): string {
+	const home = homedir();
+	return home && cwd.startsWith(home) ? `~${cwd.slice(home.length)}` : cwd;
+}
+
+let startupInfo: StartupInfo = {
+	model: "Loading…",
+	effort: "off",
+	cwd: "~",
+	tipCommands: ["/use-default-tui", "/compact", "/copy", "/hotkeys"],
+};
 
 let activeTheme: ThemeLike | undefined;
 const FALLBACK_THEME: ThemeLike = {
@@ -358,6 +412,7 @@ function twoColumn(left: string, right: string, leftWidth: number, rightWidth: n
 function compactHeader(theme: ThemeLike, width: number): string {
 	const paint = (s: string) => theme.fg("accent", s);
 	const muted = (s: string) => theme.fg("muted", s);
+	const dim = (s: string) => theme.fg("dim", s);
 	const bold = (s: string) => theme.bold(s);
 
 	if (width < 18) return paint(`Pi v${VERSION}`);
@@ -366,18 +421,26 @@ function compactHeader(theme: ThemeLike, width: number): string {
 	const innerWidth = safeWidth - 2;
 
 	// Tips sidebar (Claude Code style) on wide terminals
-	const minTipsWidth = 18;
-	const maxTipsWidth = 26;
-	const minLogoWidth = 26;
+	const minTipsWidth = 16;
+	const maxTipsWidth = 28;
+	const minLogoWidth = 28;
 	const sepWidth = 3;
 	const useTips = innerWidth >= minLogoWidth + sepWidth + minTipsWidth;
 
 	let leftWidth: number;
 	let rightWidth: number;
 	if (useTips) {
-		rightWidth = Math.min(maxTipsWidth, Math.max(minTipsWidth, Math.round(innerWidth * 0.25)));
+		rightWidth = Math.min(maxTipsWidth, Math.max(minTipsWidth, Math.round(innerWidth * 0.28)));
 		leftWidth = innerWidth - sepWidth - rightWidth;
-		if (leftWidth < minLogoWidth || rightWidth < minTipsWidth) {
+		if (leftWidth < minLogoWidth) {
+			leftWidth = minLogoWidth;
+			rightWidth = innerWidth - sepWidth - leftWidth;
+		}
+		if (leftWidth <= rightWidth) {
+			leftWidth = Math.ceil((innerWidth - sepWidth) * 0.65);
+			rightWidth = innerWidth - sepWidth - leftWidth;
+		}
+		if (rightWidth < minTipsWidth || leftWidth < minLogoWidth) {
 			leftWidth = innerWidth;
 			rightWidth = 0;
 		}
@@ -387,23 +450,26 @@ function compactHeader(theme: ThemeLike, width: number): string {
 	}
 	const actualUseTips = rightWidth >= minTipsWidth;
 
-	// Left column: logo + branding
-	const logoLines = PI_ASCII_LOGO.map((line) => centerText(theme.fg("accent", line), leftWidth));
-	const versionLine = centerText(paint(`Pi v${VERSION}`), leftWidth);
+	// Left column: logo + branding + session info
+	const info = startupInfo;
+	const logoLines = PI_CLAUDE_LOGO.map((line) => centerText(theme.fg("accent", line), leftWidth));
 	const tagline = centerText(bold("Let's build something great"), leftWidth);
-	const leftLines = [...logoLines, "", versionLine, tagline];
+	const modelLine = centerText(muted(`${info.model} · ${info.effort} effort`), leftWidth);
+	const cwdLine = centerText(dim(info.cwd), leftWidth);
+	const leftLines = [...logoLines, "", tagline, modelLine, cwdLine];
 
-	// Right column: commands + getting started
-	const COMMAND_TIPS = ["/use-default-tui", "/compact", "/copy", "/hotkeys", "/model"];
+	// Right column: getting started + commands
+	const tips = info.tipCommands;
 	const tipLines: string[] = [];
 	if (actualUseTips) {
+		const tipDivider = paint("─".repeat(Math.max(8, Math.min(rightWidth, 22))));
 		tipLines.push(
 			"",
 			bold(paint("Getting started")),
 			muted("Ask Pi to build it"),
-			paint("─".repeat(Math.min(rightWidth, 16))),
+			tipDivider,
 			bold(paint("Commands")),
-			...COMMAND_TIPS.map((cmd) => muted(cmd)),
+			...tips.map((cmd) => muted(cmd)),
 			"",
 		);
 	}
@@ -482,6 +548,16 @@ export function installStartupUiPatch(InteractiveModeComponent: any): void {
 		const scopedModels = this.session.scopedModels ?? [];
 		const availableTools = getAvailableTools(this.session);
 		const cwd = typeof this.sessionManager?.getCwd === "function" ? this.sessionManager.getCwd() : process.cwd();
+
+		// Cache session info for the claude-code-style header
+		const cmdNames = collectSlashCommandNames(skills, templates);
+		startupInfo = {
+			model: formatModelLabel(scopedModels),
+			effort: "off",
+			cwd: formatCwd(cwd),
+			tipCommands: pickSlashCommandTips(cmdNames, 3),
+		};
+
 		const agentDir = getAgentDir();
 		const systemPrompt = this.session.resourceLoader.getSystemPrompt?.();
 		const appendSystemPrompts = this.session.resourceLoader.getAppendSystemPrompt?.() ?? [];

--- a/startup-ui.ts
+++ b/startup-ui.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 
-import { getAgentDir, keyHint, rawKeyHint, VERSION } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, VERSION } from "@earendil-works/pi-coding-agent";
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { Spacer, Text } from "@earendil-works/pi-tui";
 import { safeTruncateToWidth, safeVisibleWidth } from "./render-budget.js";
@@ -322,40 +322,112 @@ function renderResourceTable(theme: ThemeLike, rows: ResourceRow[], systemContex
 	].join("\n");
 }
 
+function centerText(text: string, width: number): string {
+	if (width <= 0) return "";
+	const w = safeVisibleWidth(text);
+	if (w >= width) return safeTruncateToWidth(text, width, "…");
+	return "".repeat(Math.floor((width - w) / 2)) + text;
+}
+
+function padRight(text: string, width: number, ellipsis?: string): string {
+	const clipped = safeTruncateToWidth(text, width, ellipsis);
+	return clipped + " ".repeat(Math.max(0, width - safeVisibleWidth(clipped)));
+}
+
+function borderLine(left: string, label: string, right: string, width: number, paint: (s: string) => string): string {
+	if (width <= 1) return "";
+	if (width < 8 || label.length === 0) {
+		return paint(safeTruncateToWidth(left + "─".repeat(Math.max(0, width - 2)) + right, width, ""));
+	}
+	const before = "─── ";
+	const after = " ─────";
+	const fixedWidth = safeVisibleWidth(before) + safeVisibleWidth(label) + safeVisibleWidth(after);
+	const fill = Math.max(0, width - 2 - fixedWidth);
+	return `${paint(left)}${paint(before)}${label}${paint(after)}${paint("─".repeat(fill))}${paint(right)}`;
+}
+
+function boxedLine(content: string, width: number, paint: (s: string) => string): string {
+	if (width <= 2) return safeTruncateToWidth(content, width, "");
+	return `${paint("│")}${padRight(content, width - 2)}${paint("│")}`;
+}
+
+function twoColumn(left: string, right: string, leftWidth: number, rightWidth: number, paint: (s: string) => string): string {
+	return `${padRight(left, leftWidth)} ${paint("│")} ${padRight(right, rightWidth, "…")}`;
+}
+
 function compactHeader(theme: ThemeLike, width: number): string {
-	const logoWidth = Math.max(...PI_ASCII_LOGO.map((line) => safeVisibleWidth(line)));
-	const gap = "   ";
-	const title = theme.bold(theme.fg("accent", "Pi")) + theme.fg("dim", ` v${VERSION}`);
-	const hints = [
-		theme.bold(rawKeyHint("/", "commands")),
-		theme.bold(rawKeyHint("!", "bash")),
-		theme.bold(keyHint("app.tools.expand", "more")),
-	].join(theme.fg("muted", " · "));
-	const status = `${theme.fg("success", "●")} ${theme.bold(theme.fg("success", "ready"))}`;
-	const details = [title, hints, status, ""];
+	const paint = (s: string) => theme.fg("accent", s);
+	const muted = (s: string) => theme.fg("muted", s);
+	const bold = (s: string) => theme.bold(s);
+
+	if (width < 18) return paint(`Pi v${VERSION}`);
+
 	const safeWidth = Math.max(1, width);
-	const detailWidth = safeWidth - logoWidth - safeVisibleWidth(gap);
+	const innerWidth = safeWidth - 2;
 
-	if (detailWidth >= 12) {
-		return PI_ASCII_LOGO
-			.map((line, index) => {
-				const logoPadding = " ".repeat(Math.max(0, logoWidth - safeVisibleWidth(line)));
-				const detail = details[index] ? safeTruncateToWidth(details[index]!, detailWidth, "…") : "";
-				return `${theme.fg("accent", line)}${logoPadding}${detail ? `${gap}${detail}` : ""}`;
-			})
-			.join("\n");
+	// Tips sidebar (Claude Code style) on wide terminals
+	const minTipsWidth = 18;
+	const maxTipsWidth = 26;
+	const minLogoWidth = 26;
+	const sepWidth = 3;
+	const useTips = innerWidth >= minLogoWidth + sepWidth + minTipsWidth;
+
+	let leftWidth: number;
+	let rightWidth: number;
+	if (useTips) {
+		rightWidth = Math.min(maxTipsWidth, Math.max(minTipsWidth, Math.round(innerWidth * 0.25)));
+		leftWidth = innerWidth - sepWidth - rightWidth;
+		if (leftWidth < minLogoWidth || rightWidth < minTipsWidth) {
+			leftWidth = innerWidth;
+			rightWidth = 0;
+		}
+	} else {
+		leftWidth = innerWidth;
+		rightWidth = 0;
+	}
+	const actualUseTips = rightWidth >= minTipsWidth;
+
+	// Left column: logo + branding
+	const logoLines = PI_ASCII_LOGO.map((line) => centerText(theme.fg("accent", line), leftWidth));
+	const versionLine = centerText(paint(`Pi v${VERSION}`), leftWidth);
+	const tagline = centerText(bold("Let's build something great"), leftWidth);
+	const leftLines = [...logoLines, "", versionLine, tagline];
+
+	// Right column: commands + getting started
+	const COMMAND_TIPS = ["/use-default-tui", "/compact", "/copy", "/hotkeys", "/model"];
+	const tipLines: string[] = [];
+	if (actualUseTips) {
+		tipLines.push(
+			"",
+			bold(paint("Getting started")),
+			muted("Ask Pi to build it"),
+			paint("─".repeat(Math.min(rightWidth, 16))),
+			bold(paint("Commands")),
+			...COMMAND_TIPS.map((cmd) => muted(cmd)),
+			"",
+		);
 	}
 
-	if (safeWidth >= logoWidth) {
-		return [
-			...PI_ASCII_LOGO.map((line) => theme.fg("accent", line)),
-			safeTruncateToWidth(title, safeWidth, "…"),
-			safeTruncateToWidth(hints, safeWidth, "…"),
-			safeTruncateToWidth(status, safeWidth, "…"),
-		].join("\n");
-	}
+	// Equalize line counts
+	const maxLines = Math.max(leftLines.length, tipLines.length);
+	while (leftLines.length < maxLines) leftLines.push("");
+	while (tipLines.length < maxLines) tipLines.push("");
 
-	return [title, status].map((line) => safeTruncateToWidth(line, safeWidth, "…")).join("\n");
+	// Build bordered box
+	const topBorder = borderLine("╭", `${paint("Pi")} v${VERSION}`, "╮", safeWidth, paint);
+	const bottomBorder = borderLine("╰", "", "╯", safeWidth, paint);
+	const result: string[] = [topBorder];
+
+	for (let i = 0; i < maxLines; i++) {
+		const left = leftLines[i] ?? "";
+		const right = tipLines[i] ?? "";
+		const content = actualUseTips
+			? twoColumn(left, right, leftWidth, rightWidth, paint)
+			: padRight(left, leftWidth);
+		result.push(boxedLine(content, safeWidth, paint));
+	}
+	result.push(bottomBorder);
+	return result.join("\n");
 }
 
 export function setCompactStartupHeader(ui: ExtensionUIContext, cwd: string): void {


### PR DESCRIPTION
## Summary
Redesign the startup header to exactly match `pi-claude-code-tui` style, adapted for the current droid theme:

- **Bordered box layout**: `╭─── Pi v<version> ───────╮` top border, `│...│` rows, `╰──────────────────╯` bottom
- **Logo**: Settled Pi mark from pi-claude-code-tui (7-row, 4-cell block pattern), not the welcome-screen banner
- **Left column**: Pi mark (centered) → "Let's build something great" (bold) → model provider/id and thinking effort (muted) → cwd (dim) — all using real session data
- **Right column** (wide terminals ≥ ~85 cols): "Getting started" → "Ask Pi to build it" → separator → "Commands" → 4 real Pi slash commands (1 fixed + 3 random from session)
- **Narrow terminals**: Auto-collapse to single-column centered layout
- **All colors** use active Pi theme (accent, muted, dim, bold) — no hardcoded colors

## Changes
- `PI_ASCII_LOGO` → `PI_CLAUDE_LOGO` (settled 7×12 Pi mark)
- New `startupInfo` module-level cache with model, effort, cwd, tipCommands
- New helpers: `collectSlashCommandNames()`, `pickSlashCommandTips()`, `formatModelLabel()`, `formatCwd()`
- `installStartupUiPatch` populates `startupInfo` from session data at startup
- `compactHeader` uses real session commands, model provider/id, cwd
- Layout proportions match pi-claude-code-tui (28% tips, 65/35 split when close)

## Test plan
- [ ] `/reload` and confirm the startup header shows the claude-code bordered box
- [ ] Verify the settled Pi mark logo (not welcome-screen banner) is centered on the left
- [ ] Confirm model provider/id and cwd are shown with real session data
- [ ] On a wide terminal, confirm the tips sidebar with Getting started + real Commands appears
- [ ] On a narrow terminal (< ~85 cols), layout collapses to centered single column
- [ ] Switch themes (/theme) and confirm box borders and text update with active theme
- [ ] Run `npm run test:startup-resources` and `npm run test:theme-extras`